### PR TITLE
Add id to NuGet Login step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This GitHub Action enables secure, passwordless authentication to NuGet servers 
 
 ```yaml
 - name: NuGet Login
+  id: login
   uses: NuGet/login@v1
   with:
     user: my-nuget-username


### PR DESCRIPTION
- The first example is incomplete, and if we just copy that snippet the deployment will fail